### PR TITLE
Using one-way binding blocks updates

### DIFF
--- a/todo/todo-list.html
+++ b/todo/todo-list.html
@@ -45,7 +45,7 @@
       </button>
     </form>
     <ul>
-      <template is="dom-repeat" items="[[todos]]" as="todo">
+      <template is="dom-repeat" items="{{todos}}" as="todo">
         <todo-item todo="{{todo}}"></todo-item>
       </template>
     </ul>


### PR DESCRIPTION
When using one-way binding in the repeat it will prevent updates from propagating back up from any elements within.
